### PR TITLE
Require importlib-metadata when Python version is <3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ setup_requires =
 install_requires =
     pyqt5
     qtpy
+    importlib-metadata; python_version < "3.8"
 include_package_data = True
 packages = find:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ setup_requires =
     setuptools_scm_git_archive
 install_requires =
     pyqt5
-    qtpy
+    qt.py
     importlib-metadata; python_version < "3.8"
 include_package_data = True
 packages = find:


### PR DESCRIPTION
The `importlib-metadata` package needs to be installed when Python version is <3.8 to provide functionality back-ported from the Python3.8 version of `importlib`.