### PR TITLE
Add filenames as titles of gifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Command line argumens:
 
 ``-h, --help`` : print help text
 
+``-n, --no-titles``: turn off titles over each gif
+
 ``-v, --version`` : print the version number
 
 ### In Python code
@@ -66,7 +68,8 @@ MultiGifView can be used from within Python code.
     >>> show_gifs("gif1.gif", "gif2.gif")
 
 Any number of gifs can be passed as positional arguments. ``max_columns`` can
-be passed as a keyword argument.
+be passed as a keyword argument. An argument ``titles=False`` can be passed to
+turn off titles above gifs.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Once the window is opened:
 Command line argumens:
 
 ``-c, --max-columns <i>`` : use at most ``<i>`` columns for display
+
 ``-h, --help`` : print help text
+
 ``-v, --version`` : print the version number
 
 ### In Python code

--- a/multigifview/__main__.py
+++ b/multigifview/__main__.py
@@ -8,7 +8,7 @@ import sys
 from .core import MultiGifView
 
 
-def show_gifs(*filenames, max_columns=2):
+def show_gifs(*filenames, max_columns=2, titles=True):
     """Show gifs in a Qt window
 
     Any number of gifs can be opened. Each will be in a new column until there are
@@ -23,7 +23,7 @@ def show_gifs(*filenames, max_columns=2):
         Maximum number of columns to use
     """
     app = QApplication(sys.argv)
-    window = MultiGifView(filenames, max_columns=max_columns)
+    window = MultiGifView(filenames, max_columns=max_columns, titles=titles)
     window.show()
     window.reset_minimum_size()
 
@@ -56,6 +56,13 @@ def main():
         type=int,
         default=2,
     )
+    parser.add_argument(
+        "-n",
+        "--no-titles",
+        action="store_true",
+        default=False,
+        help="Disable titles above gifs",
+    )
     from multigifview import __version__
 
     parser.add_argument(
@@ -63,7 +70,9 @@ def main():
     )
     args = parser.parse_args()
 
-    exit_code = show_gifs(*args.file, max_columns=args.max_columns)
+    exit_code = show_gifs(
+        *args.file, max_columns=args.max_columns, titles=not args.no_titles
+    )
 
     sys.exit(exit_code)
 

--- a/multigifview/core.py
+++ b/multigifview/core.py
@@ -13,12 +13,13 @@ from Qt.QtWidgets import (
 )
 from Qt.QtGui import QMovie, QKeySequence
 from Qt.QtCore import QSize
+from Qt.QtCore import Qt as QtCoreQt
 
 
 class MultiGifView(QMainWindow, Ui_MainWindow):
     """A program for viewing .gif files"""
 
-    def __init__(self, filenames, *, max_columns):
+    def __init__(self, filenames, *, max_columns, titles):
         super().__init__(None)
         self.setupUi(self)
 
@@ -79,6 +80,7 @@ class MultiGifView(QMainWindow, Ui_MainWindow):
         for i, arg in enumerate(filenames):
             gif_widget = QLabel(self.centralwidget)
             gif_widget.setText("")
+            gif_widget.setToolTip(arg)
             gif_widget.setObjectName(f"gif_widget{i + 1}")
 
             filepath = Path(arg)
@@ -91,6 +93,16 @@ class MultiGifView(QMainWindow, Ui_MainWindow):
 
             column = self.columns[i % n_columns]
             position = column.count() - 1
+
+            if titles:
+                title_widget = QLabel(self.centralwidget)
+                title_widget.setText(arg)
+                title_widget.setAlignment(QtCoreQt.AlignCenter)
+                title_widget.setObjectName(f"title_widget{i + 1}")
+
+                column.insertWidget(position, title_widget)
+                position = position + 1
+
             column.insertWidget(position, gif_widget)
 
             self.extra_movies.append(movie)


### PR DESCRIPTION
Command line option allows turning the titles off.

Also adds a tooltip (always on), also showing the filename.